### PR TITLE
Centos support

### DIFF
--- a/libraries/etcd_client.rb
+++ b/libraries/etcd_client.rb
@@ -44,7 +44,7 @@ module ETCD
 
         hosts.map { |host| ports.map do |port|
           uri_class(protocol).build(:host => host, :port => port)
-        end }.flatten.sort
+        end }.flatten.sort_by {|uri| uri.to_s}
       end
 
       ## Return the correct URI class for a given protocol scheme

--- a/libraries/etcd_service.rb
+++ b/libraries/etcd_service.rb
@@ -243,7 +243,7 @@ class Chef
         peers.select(&:online?)
       end
 
-      ## Get Chef::Resource for etcd instnace
+      ## Get Chef::Resource for etcd instance
       def instance_resource
         instance.is_a?(Resource::Etcd) ? instance : resources(instance)
       end
@@ -271,7 +271,8 @@ class Chef
         ## Only add our self to the cluster list if we're not a proxy
         cluster += peer_advertise_urls.map { |url| "#{ node_name }=#{ url }" } if proxy == :off
 
-        cluster.sort
+        ## Remove possible duplicates after adding self to the cluster, and return it sorted.
+        cluster.uniq.sort
       end
     end
   end

--- a/metadata.rb
+++ b/metadata.rb
@@ -29,6 +29,7 @@ long_description IO.read('README.md') rescue ''
 version IO.read('VERSION') rescue '0.0.1'
 
 supports 'ubuntu'
+supports 'centos'
 
 depends 'apt'
 depends 'libarchive', '>= 0.5.0'

--- a/providers/service.rb
+++ b/providers/service.rb
@@ -69,6 +69,17 @@ action :configure do
     variables :resource => new_resource,
               :instance => new_resource.instance_resource,
               :arguments => build_arguments
+    only_if { node['platform_family'] == 'debian' }
+  end
+
+  # Init.d service config
+  template "/etc/init.d/etcd-#{new_resource.name}" do
+    cookbook 'etcd-v2'
+    source 'etcd.initd.erb'
+    backup false
+    mode 0755
+    variables :arguments => build_arguments
+    only_if { node['platform_family'] == 'rhel' }
   end
 
   ## Create the state-store directory
@@ -83,6 +94,7 @@ action :configure do
     supports :restart => true, :status => true
     action new_resource.service_action
 
-    provider Chef::Provider::Service::Upstart
+    provider Chef::Provider::Service::Upstart if node['platform_family'] == 'debian'
+    provider Chef::Provider::Service::Init::Redhat if node['platform_family'] == 'rhel'
   end
 end

--- a/templates/default/etcd.initd.erb
+++ b/templates/default/etcd.initd.erb
@@ -1,103 +1,90 @@
 #!/bin/bash
 #
-# etcd      This shell script takes care of starting and stopping
-#             etcd
+# etcd      This shell script takes care of starting and stopping etcd
 #
 # chkconfig: 345 80 30
 # description:  etcd service registry
 
-# processname: etcd
-# pidfile: /var/run/etcd/etcd.pid
-
 # Source function library.
-. /lib/lsb/init-functions
-
-# Source etcd configuration
-if [ -f /etc/default/etcd ] ; then
- . /etc/default/etcd
-fi
+. /etc/rc.d/init.d/functions
 
 RETVAL=0
-prog="etcd"
+
+prog=`basename $0`
+etcd=/usr/local/bin/etcd
+
+lockfile=/var/lock/subsys/$prog
+pidfile=/var/run/$prog.pid
+
+STDOUT=/var/log/$prog.log
+STDERR=/var/log/$prog.err
+STOP_TIMEOUT=${STOP_TIMEOUT-10}
 
 start() {
- # Start daemons.
- echo -n $"Starting $prog: "
- PID=`pidof etcd`
- if [ ! -z $PID ]; then
-   return 2
- fi
- /usr/local/bin/etcd <%= @arguments.join("\\\n  ") %> > /var/log/etcd 2> /var/log/etcd.err &
- RETVAL=$?
- echo
- [ $RETVAL -eq 0 ] && touch /var/lock/etcd
- return $RETVAL
+  status_log=$(status -p $pidfile $prog)
+  RETVAL=$?
+  if [ $RETVAL -eq 0 ]; then
+    echo $status_log
+    return
+  fi
+
+  echo -n "Starting $prog:"
+  touch $pidfile
+
+  # Start daemon.
+  daemon \
+    --pidfile=$pidfile \
+    "{ /usr/local/bin/etcd \
+      <%= @arguments.join("\\\n  ") %> \
+      > $STDOUT 2> $STDERR &
+    }; echo \$! >| $pidfile" && success || failure
+
+  RETVAL=$?
+  [ $RETVAL -eq 0 ] && touch $lockfile
+  echo
 }
 
 stop() {
- # Stop daemons.
- echo -n $"Shutting down $prog: "
- PID=`pidof etcd`
- if [ ! -z $PID ]; then
-   kill -9 $PID
- fi
- RETVAL=$?
- echo
- [ $RETVAL -eq 0 ] && rm -f /var/lock/etcd
- return $RETVAL
+  status_log=$(status -p $pidfile $prog)
+  RETVAL=$?
+  if [ $RETVAL -ne 0 ]; then
+    echo $status_log
+    return
+  fi
+
+  echo -n $"Stopping $prog: "
+
+  # Stop daemon.
+  killproc -p ${pidfile} -d ${STOP_TIMEOUT} $etcd && success || failure
+  RETVAL=$?
+  echo
+  [ $RETVAL -eq 0 ] && rm -f $pidfile $lockfile
 }
 
-status() {
- PID=`pidof etcd`
- if [ ! -z $PID ]; then
-   echo "etcd is running running with pid $PID"
-   return 0
- else
-   echo "etcd is not running"
-   return 1
- fi
-}
-
-reload() {
- # Reload daemons.
- echo -n $"Reloading $prog: "
- kill -1 `pidof etcd`
- RETVAL=$?
- echo
- return $RETVAL
+restart() {
+  stop
+  sleep 1
+  start
+  RETVAL=$?
 }
 
 # See how we were called.
 case "$1" in
   start)
- start
- ;;
+    start
+    ;;
   stop)
- stop
- ;;
+    stop
+    ;;
   restart)
- stop
- start
- RETVAL=$?
- ;;
-  condrestart)
- if [ -f /var/lock/etcd ]; then
-     stop
-     start
-     RETVAL=$?
- fi
- ;;
+    restart
+    ;;
   status)
- status
- RETVAL=$?
- ;;
-  reload)
- reload
- RETVAL=$?
- ;;
+    status -p $pidfile $prog
+    ;;
   *)
- echo $"Usage: $0 {start|stop|restart|reload|condrestart|status}"
- exit 1
+    echo $"Usage: $0 {start|stop|restart|status}"
+    exit 1
 esac
 
 exit $RETVAL

--- a/templates/default/etcd.initd.erb
+++ b/templates/default/etcd.initd.erb
@@ -1,0 +1,103 @@
+#!/bin/bash
+#
+# etcd      This shell script takes care of starting and stopping
+#             etcd
+#
+# chkconfig: 345 80 30
+# description:  etcd service registry
+
+# processname: etcd
+# pidfile: /var/run/etcd/etcd.pid
+
+# Source function library.
+. /lib/lsb/init-functions
+
+# Source etcd configuration
+if [ -f /etc/default/etcd ] ; then
+ . /etc/default/etcd
+fi
+
+RETVAL=0
+prog="etcd"
+
+start() {
+ # Start daemons.
+ echo -n $"Starting $prog: "
+ PID=`pidof etcd`
+ if [ ! -z $PID ]; then
+   return 2
+ fi
+ /usr/local/bin/etcd <%= @arguments.join("\\\n  ") %> > /var/log/etcd 2> /var/log/etcd.err &
+ RETVAL=$?
+ echo
+ [ $RETVAL -eq 0 ] && touch /var/lock/etcd
+ return $RETVAL
+}
+
+stop() {
+ # Stop daemons.
+ echo -n $"Shutting down $prog: "
+ PID=`pidof etcd`
+ if [ ! -z $PID ]; then
+   kill -9 $PID
+ fi
+ RETVAL=$?
+ echo
+ [ $RETVAL -eq 0 ] && rm -f /var/lock/etcd
+ return $RETVAL
+}
+
+status() {
+ PID=`pidof etcd`
+ if [ ! -z $PID ]; then
+   echo "etcd is running running with pid $PID"
+   return 0
+ else
+   echo "etcd is not running"
+   return 1
+ fi
+}
+
+reload() {
+ # Reload daemons.
+ echo -n $"Reloading $prog: "
+ kill -1 `pidof etcd`
+ RETVAL=$?
+ echo
+ return $RETVAL
+}
+
+# See how we were called.
+case "$1" in
+  start)
+ start
+ ;;
+  stop)
+ stop
+ ;;
+  restart)
+ stop
+ start
+ RETVAL=$?
+ ;;
+  condrestart)
+ if [ -f /var/lock/etcd ]; then
+     stop
+     start
+     RETVAL=$?
+ fi
+ ;;
+  status)
+ status
+ RETVAL=$?
+ ;;
+  reload)
+ reload
+ RETVAL=$?
+ ;;
+  *)
+ echo $"Usage: $0 {start|stop|restart|reload|condrestart|status}"
+ exit 1
+esac
+
+exit $RETVAL

--- a/templates/default/etcd.initd.erb
+++ b/templates/default/etcd.initd.erb
@@ -32,12 +32,9 @@ start() {
   touch $pidfile
 
   # Start daemon.
-  daemon \
-    --pidfile=$pidfile \
-    "{ /usr/local/bin/etcd \
-      <%= @arguments.join("\\\n  ") %> \
-      > $STDOUT 2> $STDERR &
-    }; echo \$! >| $pidfile" && success || failure
+  $etcd <%= @arguments.join("\\\n  ") %> > $STDOUT 2> $STDERR &
+  echo $! >| $pidfile
+  status_log=$(status -p $pidfile $prog) && success || failure
 
   RETVAL=$?
   [ $RETVAL -eq 0 ] && touch $lockfile
@@ -47,7 +44,7 @@ start() {
 stop() {
   status_log=$(status -p $pidfile $prog)
   RETVAL=$?
-  if [ $RETVAL -ne 0 ]; then
+  if [ $RETVAL -eq 3 ]; then
     echo $status_log
     return
   fi


### PR DESCRIPTION
Added support for centos:
- Added template for initd etcd service
- Update service provider to use initd when provision 'rhel' platform family, and upstart when 'debian'
## \- Updated metadata with 'supports centos'

Added safe code to avoid cluster duplicated peers.
